### PR TITLE
[FEAT] 리포트 생성 요청 시 Task 생성하고 각 토픽에 메시지 발행

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -40,7 +40,14 @@ jobs:
           cd deploy-configs
           docker-compose stop fastapi-app || true
           docker-compose rm -f fastapi-app || true
-
+      
+      # kafka-consumer가 실행중인 경우 중지
+      - name: Stop kafka-consumer
+        run: |
+          cd deploy-configs
+          docker-compose stop kafka-consumer || true
+          docker-compose rm -f kafka-consumer || true
+      
       # fastapi-app 다시 실행
       - name: Deploy fastapi-app
         working-directory: deploy-configs
@@ -56,3 +63,15 @@ jobs:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
           docker-compose up -d --no-deps fastapi-app
+
+      # kafka-consumer 다시 실행
+      - name: Deploy kafka-consumer
+        working-directory: deploy-configs
+        env:
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PORT: "3306"
+          DB_DATABASE: "channeling"
+          DB_USER: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+        run: |
+          docker-compose up -d --no-deps kafka-consumer

--- a/core/config/kafka_config.py
+++ b/core/config/kafka_config.py
@@ -7,7 +7,8 @@ class KafkaConfig(BaseSettings):
     """Kafka 설정 클래스(환경 변수와 기본값 관리)"""
 
     # 브로커 서버 주소 등록(클러스터 구성 시 여러 주소 가능)
-    bootstrap_servers: List[str] = ["broker:29092"]
+    # bootstrap_servers: List[str] = ["broker:29092"]
+    bootstrap_servers: List[str] = ["localhost:9092"]
     # 보안 프로토콜 설정
     security_protocol: str = "PLAINTEXT"
 
@@ -33,3 +34,8 @@ class KafkaConfig(BaseSettings):
     overview_topic: str = "overview-topic"
     analysis_topic: str = "analysis-topic"
     idea_topic: str = "idea-topic"
+
+    class Config:
+        # 환경 변수에서 설정값을 읽어옴
+        env_prefix = "KAFKA_"
+        env_file=".env"

--- a/core/config/kafka_config.py
+++ b/core/config/kafka_config.py
@@ -39,3 +39,4 @@ class KafkaConfig(BaseSettings):
         # 환경 변수에서 설정값을 읽어옴
         env_prefix = "KAFKA_"
         env_file=".env"
+        extra = "ignore"

--- a/core/database/model/report.py
+++ b/core/database/model/report.py
@@ -11,7 +11,7 @@ class Report(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     
     # Foreign Key - Video 테이블 참조
-    video_id: int = Field(foreign_key="video.id")
+    video_id: int = Field(description="영상 ID")
     
     # 영상 정보
     title: str = Field(description="영상 제목")

--- a/core/kafka/kafka_broker.py
+++ b/core/kafka/kafka_broker.py
@@ -1,0 +1,5 @@
+from faststream.kafka import KafkaBroker
+from core.config.kafka_config import KafkaConfig
+
+# 전역 Kafka Broker 설정
+kafka_broker = KafkaBroker(KafkaConfig().bootstrap_servers)

--- a/domain/report/controller/report_controller.py
+++ b/domain/report/controller/report_controller.py
@@ -1,15 +1,62 @@
 from fastapi import APIRouter, HTTPException
+from core.kafka.message import Message
+from core.database.model.report import Report
+from core.kafka.message import Step
+from domain.report.repository.report_repository import ReportRepository
+from domain.task.repository.task_repository import TaskRepository
+from domain.report.service.report_producer import ReportProducer
+from faststream.kafka import KafkaBroker
+from core.config.kafka_config import KafkaConfig
+
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 
+report_repository = ReportRepository()
+task_repository = TaskRepository()
+report_producer = ReportProducer(KafkaBroker, KafkaConfig)
 
 @router.post("")
-async def create_report() -> int:
+async def create_report(video_id: int) -> int:
     """
     리포트 생성을 시작합니다.
     parameters:
-        None
+        video_id: int - 리포트에 대한 영상 ID
     returns:
         task_id: int
     """
-    ...
+    # report 생성
+    report_data = {"video_id": video_id}
+    report = await report_repository.save(data=report_data)
+    print(f"Report created with ID: {report.id}")
+    
+    # task 생성
+    task_data = {"report_id": report.id}
+    task = await task_repository.save(data=task_data)
+    print(f"Task created with ID: {task.id}")
+
+    # 메시지 생성
+    overview_message= Message(
+        task_id=task.id,
+        report_id=report.id,
+        step=Step.overview
+    )
+
+    analysis_message = Message(
+        task_id=task.id,
+        report_id=report.id,
+        step=Step.analysis
+    )
+
+    idea_message = Message(
+        task_id=task.id,
+        report_id=report.id,
+        step=Step.idea
+    )
+
+    # 메시지 발행
+    report_producer.send_message("overview-topic", overview_message)
+    report_producer.send_message("analysis-topic", analysis_message)
+    report_producer.send_message("idea-topic", idea_message)
+
+    # return task.id
+    return None

--- a/domain/report/repository/report_repository.py
+++ b/domain/report/repository/report_repository.py
@@ -1,11 +1,11 @@
 from core.database.model.report import Report
 from core.database.repository.crud_repository import CRUDRepository
 
-class ReportRepository(CRUDRepository):
+class ReportRepository(CRUDRepository[Report]):
     def model_class(self) -> type[Report]:
         """Report 모델 클래스를 반환합니다."""
         return Report
     
-    
+
     
     

--- a/domain/report/service/report_consumer.py
+++ b/domain/report/service/report_consumer.py
@@ -1,0 +1,23 @@
+
+from abc import abstractmethod
+from ast import Dict
+from typing import Any
+from core.kafka.base_consumer import BaseConsumer
+
+
+class ReportConsumer(BaseConsumer):
+    
+    @abstractmethod
+    async def handle_overview(self):
+        """보고서 개요 요청 처리"""
+        pass
+    
+    @abstractmethod
+    async def handle_analysis(self):
+        """보고서 분석 요청 처리"""
+        pass
+    
+    @abstractmethod
+    async def handle_idea(self):
+        """보고서 아이디어 요청 처리"""
+        pass

--- a/domain/report/service/report_consumer_impl.py
+++ b/domain/report/service/report_consumer_impl.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict
+from domain.report.service.report_consumer import ReportConsumer
+import logging
+
+logger = logging.getLogger(__name__)
+
+class ReportConsumerImpl(ReportConsumer):
+    async def handle_overview(self):
+        """보고서 개요 요청 처리"""
+        logger.info(f"Handling overview request")
+        print("Overview request processing logic goes here")
+        
+
+    async def handle_analysis(self):
+        """보고서 분석 요청 처리"""
+        logger.info(f"Handling analysis request")
+        print("Analysis request processing logic goes here")
+
+    async def handle_idea(self):
+        """보고서 아이디어 요청 처리"""
+        logger.info(f"Handling idea request")
+        print("Idea request processing logic goes here")

--- a/domain/report/service/report_producer.py
+++ b/domain/report/service/report_producer.py
@@ -1,0 +1,5 @@
+from core.kafka.base_producer import BaseProducer
+
+
+class ReportProducer(BaseProducer):
+    ...

--- a/domain/report/service/report_producer_impl.py
+++ b/domain/report/service/report_producer_impl.py
@@ -1,0 +1,7 @@
+from domain.report.service.report_producer import ReportProducer
+
+
+class ReportProducerImpl(ReportProducer):
+    async def produce(self, topic: str, key: str, value: str) -> None:
+        # Kafka에 메시지를 전송하는 로직 구현
+        pass

--- a/domain/task/repository/task_repository.py
+++ b/domain/task/repository/task_repository.py
@@ -1,0 +1,8 @@
+from core.database.model.task import Task
+from core.database.repository.crud_repository import CRUDRepository
+
+
+class TaskRepository(CRUDRepository[Task]):
+    def model_class(self) -> type[Task]:
+        """Task 모델 클래스를 반환합니다."""
+        return Task

--- a/kafka_consumer.py
+++ b/kafka_consumer.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from faststream.kafka import KafkaBroker
 from core.config.kafka_config import KafkaConfig
-from domain.report.service.report_consumer import ReportConsumer
+from domain.report.service.report_consumer_impl import ReportConsumerImpl as ReportConsumer
 
 
 logging.basicConfig(level=logging.INFO)
@@ -15,16 +15,15 @@ async def main():
     broker = KafkaBroker(KafkaConfig().bootstrap_servers)
     
     report_consumer = ReportConsumer(broker)
-    report_consumer.register_handler("report-requests", report_consumer.handle_overview)
-    report_consumer.register_handler("analysis-generation", report_consumer.handle_analysis)
-    report_consumer.register_handler("idea-generation", report_consumer.handle_idea)
-    
-     
+    report_consumer.register_handler("overview-topic", report_consumer.handle_overview)
+    report_consumer.register_handler("analysis-topic", report_consumer.handle_analysis)
+    report_consumer.register_handler("idea-topic", report_consumer.handle_idea)
+
     await broker.start()
     logger.info("= Kafka Broker 시작 완료")
 
     # Consumer 시작
-    topics = ["report-requests", "analysis-generation", "idea-generation"]
+    topics = ["overview-topic", "analysis-topic", "idea-topic"]
     await report_consumer.start_consuming(topics)
     logger.info(f"= Kafka Consumer 시작: {topics}")
     

--- a/kafka_consumer.py
+++ b/kafka_consumer.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
-from faststream.kafka import KafkaBroker
-from core.config.kafka_config import KafkaConfig
+from core.kafka.kafka_broker import kafka_broker
 from domain.report.service.report_consumer_impl import ReportConsumerImpl as ReportConsumer
 
 
@@ -12,14 +11,13 @@ logger = logging.getLogger(__name__)
 async def main():
     """Kafka Consumer 시작"""
     logger.info("= Kafka Consumer 시작...")
-    broker = KafkaBroker(KafkaConfig().bootstrap_servers)
-    
-    report_consumer = ReportConsumer(broker)
+  
+    report_consumer = ReportConsumer(kafka_broker)
     report_consumer.register_handler("overview-topic", report_consumer.handle_overview)
     report_consumer.register_handler("analysis-topic", report_consumer.handle_analysis)
     report_consumer.register_handler("idea-topic", report_consumer.handle_idea)
 
-    await broker.start()
+    await kafka_broker.start()
     logger.info("= Kafka Broker 시작 완료")
 
     # Consumer 시작
@@ -36,7 +34,7 @@ async def main():
     finally:
         
         await report_consumer.stop_consuming()
-        await broker.close()
+        await kafka_broker.close()
         logger.info("= Kafka Consumer 중단 완료")
 
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from domain.report.controller.report_controller import router as report_router
 from response.code.status.success_status import SuccessStatus
 from response.api_response import ApiResponse
 from response.code.status.error_status import ErrorStatus
+from core.kafka.kafka_broker import kafka_broker
 
 '''
 서버 시작 명령어: fastapi dev main.py
@@ -14,7 +15,7 @@ app = FastAPI(title="Channeling LLM API", version="1.0.0")
 # 라우터 등록
 app.include_router(report_router)
 
-# 앱 시작 시 DB 연결 확인만
+
 @app.on_event("startup")
 async def on_startup():
     print("🚀 서버 시작 중...")
@@ -24,6 +25,19 @@ async def on_startup():
         print("✅ DB에 연결 완료")
     else:
         print("❌ DB 연결 실패")
+
+    # kafka 브로커 시작
+    await kafka_broker.start()
+    print("✅ Kafka 브로커 시작 완료")
+
+@app.on_event("shutdown")
+async def on_shutdown():
+
+    print("🛑 서버 종료 중...")
+    
+    # kafka 브로커 종료
+    await kafka_broker.close()
+    print("✅ Kafka 브로커 종료 완료")
 
 @app.get("/health")
 async def health_check():


### PR DESCRIPTION
## PR 제목
[FEAT] 리포트 생성 요청 시 Task 생성하고 각 토픽에 메시지 발행

## ✨ 변경 유형 (하나 이상 선택)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
- 브로커 연결 전역 인스턴스로 빼서 관리하는 방식으로 변경했습니다.
- Report consumer, producer, controller 추가했습니다.
- 자잘한 오류 수정했습니다.
- 배포 환경에서 kafka-consumer를 추가해서 CD.yml을 수정했습니다.
- 개요, 분석, 아이디어 토픽에 메시지 발행하는 거 추가했습니다.
<img width="1894" height="548" alt="image" src="https://github.com/user-attachments/assets/8e19012a-dce0-486d-8f22-72f6ef135286" />
<img width="1664" height="302" alt="image" src="https://github.com/user-attachments/assets/dfd4fce4-3c1c-4fed-b390-a34ab3ddaec5" />

- 메시지 발행 잘 되는 거 확인했습니다.

## ⚙️ 주요 작업 (선택 사항)
- [x] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다.
- [x] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
#6 

## 💬 기타 (선택 사항)