### PR TITLE
[BUG] config에서 str 형식으로 받게 수정 (#11)

### DIFF
--- a/core/config/kafka_config.py
+++ b/core/config/kafka_config.py
@@ -6,9 +6,8 @@ from pydantic_settings import BaseSettings
 class KafkaConfig(BaseSettings):
     """Kafka 설정 클래스(환경 변수와 기본값 관리)"""
 
-    # 브로커 서버 주소 등록(클러스터 구성 시 여러 주소 가능)
-    # bootstrap_servers: List[str] = ["broker:29092"]
-    bootstrap_servers: List[str] = ["localhost:9092"]
+    # 브로커 서버 주소 등록(환경변수에서 문자열로 받음)
+    bootstrap_servers: str = "localhost:9092"
     # 보안 프로토콜 설정
     security_protocol: str = "PLAINTEXT"
 
@@ -38,5 +37,9 @@ class KafkaConfig(BaseSettings):
     class Config:
         # 환경 변수에서 설정값을 읽어옴
         env_prefix = "KAFKA_"
-        env_file=".env"
+        env_file = ".env"
         extra = "ignore"
+
+
+# 전역에서 사용할 설정 인스턴스 (싱글톤 패턴)
+kafka_config = KafkaConfig()

--- a/core/kafka/kafka_broker.py
+++ b/core/kafka/kafka_broker.py
@@ -1,5 +1,7 @@
 from faststream.kafka import KafkaBroker
-from core.config.kafka_config import KafkaConfig
+from core.config.kafka_config import kafka_config
 
-# 전역 Kafka Broker 설정
-kafka_broker = KafkaBroker(KafkaConfig().bootstrap_servers)
+
+
+# 전역 Kafka Broker 설정 (기존 인스턴스 사용)
+kafka_broker = KafkaBroker(kafka_config.bootstrap_servers)


### PR DESCRIPTION
## PR 제목
[BUG] config에서 str 형식으로 받게 수정 (#11)

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
- bootstrap_servers(브로커 서버 주소)를 List 가 아닌 str 형식으로 받게 하여 환경 변수가 제대로 전달되게 수정했습니다.
- kafka_config 인스턴스를 생성해 전역에서 쓸 수 있게 하여 싱글톤 패턴을 유지하게 변경했습니다.

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
#10 

## 💬 기타 (선택 사항)