### PR TITLE
[BUG] 이탈 분석 타임아웃 에러 해결 

### DIFF
--- a/domain/report/controller/report_controller.py
+++ b/domain/report/controller/report_controller.py
@@ -79,8 +79,8 @@ async def create_report(video_id: int):
 
     # 메시지 발행
     await report_producer.send_message("overview-topic", overview_message)
-    # await report_producer.send_message("analysis-topic", analysis_message)
-    # await report_producer.send_message("idea-topic", idea_message)
+    await report_producer.send_message("analysis-topic", analysis_message)
+    await report_producer.send_message("idea-topic", idea_message)
 
     return ApiResponse.on_success(SuccessStatus._OK, {"task_id": task.id})
 

--- a/domain/report/service/report_consumer_impl.py
+++ b/domain/report/service/report_consumer_impl.py
@@ -141,27 +141,33 @@ class ReportConsumerImpl(ReportConsumer):
             seo = await video_service.analyze_seo(video)
             revisit = await video_service.analyze_revisit(video)
 
-            print(f"조회수 : {video.view}")
-            print(f"조회수평균-채널 : {avg_dic['view_avg']}")
-            print(f"조회수평균-토픽 : {avg_dic['view_category_avg']}")
-            print(f"좋아요 : {video.like_count}")
-            print(f"좋아요평균-토픽 : {avg_dic['like_avg']}")
-            print(f"좋아요평균-채널 : {avg_dic['like_category_avg']}")
-            print(f"댓글 : {video.comment_count}")
-            print(f"댓글평균-토픽 : {avg_dic['comment_avg']}")
-            print(f"댓글평균-채널 : {avg_dic['comment_category_avg']}")
+            logger.info(f"조회수 : {video.view}")
+            logger.info(f"조회수평균-채널 : {avg_dic['view_avg']}")
+            logger.info(f"조회수평균-토픽 : {avg_dic['view_category_avg']}")
+            logger.info(f"좋아요 : {video.like_count}")
+            logger.info(f"좋아요평균-토픽 : {avg_dic['like_avg']}")
+            logger.info(f"좋아요평균-채널 : {avg_dic['like_category_avg']}")
+            logger.info(f"댓글 : {video.comment_count}")
+            logger.info(f"댓글평균-토픽 : {avg_dic['comment_avg']}")
+            logger.info(f"댓글평균-채널 : {avg_dic['comment_category_avg']}")
 
-            print(f"일관성 : {concept}")
-            print(f"seo : {seo}")
-            print(f"재방문률 : {revisit}")
+            logger.info(f"일관성 : {concept}")
+            logger.info(f"seo : {seo}")
+            logger.info(f"재방문률 : {revisit}")
 
             # 요약 정보 업데이트
             await self.report_repository.save({
                 "id": report_id,
                 # 영상 평가
                 "like_count": video.like_count,
+                "like_channel_avg": avg_dic['like_category_avg'],
+                "like_topic_avg": avg_dic['like_avg'],
                 "comment" : video.comment_count,
+                "comment_channel_avg": avg_dic['comment_category_avg'],
+                "comment_topic_avg": avg_dic['comment_avg'],
                 "view" : video.view,
+                "view_channel_avg": avg_dic['view_avg'],
+                "view_topic_avg": avg_dic['view_category_avg'],
                 "concept" : concept,
                 "seo" : seo,
                 "revisit" : revisit,


### PR DESCRIPTION
## PR 제목
[BUG] 이탈 분석 타임아웃 에러 해결 

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
- 분석 페이지 단독 생성 시에는 문제 없지만, 전체 페이지 생성 시에 항상 Connection timeout 에러 발생
- 재시도 로직 추가해서 예외 발생 원인이 네트워크 관련이면, 3번까지 재시도하는 로직 추가
- 보통 2번 째에 성공하는 거 확인

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
#55 

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.