### PR TITLE
[FEAT] 한국 시간으로 저장되게 설정

### DIFF
--- a/core/config/database_config.py
+++ b/core/config/database_config.py
@@ -24,7 +24,7 @@ PG_PASSWORD = os.getenv("PG_PASSWORD")
 PG_DATABASE = os.getenv("PG_DATABASE")
 
 # 비동기 MySQL 연결 URL
-MYSQL_DATABASE_URL = f"mysql+aiomysql://{MYSQL_USER}:{MYSQL_PASSWORD}@{MYSQL_HOST}:{MYSQL_PORT}/{MYSQL_DATABASE}"
+MYSQL_DATABASE_URL = f"mysql+aiomysql://{MYSQL_USER}:{MYSQL_PASSWORD}@{MYSQL_HOST}:{MYSQL_PORT}/{MYSQL_DATABASE}?charset=utf8mb4"
 
 # 비동기 PostgreSQL 연결 URL
 # 로컬 개발환경인지 확인 (localhost나 127.0.0.1이면 SSL 비활성화)
@@ -41,6 +41,9 @@ mysql_engine = create_async_engine(
     echo=False,  # SQL 쿼리 로그 출력 비활성화
     pool_pre_ping=True,  # 연결 상태 체크
     pool_recycle=300,  # 연결 재사용 시간 (5분)
+    connect_args={
+        "init_command": "SET time_zone = '+09:00'"  # KST 타임존 설정
+    }
 )
 
 # PostgreSQL 엔진


### PR DESCRIPTION
db 커넥션 시작할 때마다 +9시간 더하는 커맨드 추가

## PR 제목
[FEAT] 한국 시간으로 저장되게 설정

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
- UTC -> KR

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
#103 

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.