### PR TITLE
[BUG]: 이탈 분석 시, content-size 에러

### DIFF
--- a/domain/trend_keyword/controller/trend_keyword_controller.py
+++ b/domain/trend_keyword/controller/trend_keyword_controller.py
@@ -23,7 +23,8 @@ async def create_real_time_keyword():
 
 
     realtime_keyword = rag_service.analyze_realtime_trends()
-    logger.info(f"실시간 트렌드 LLM 응답: {realtime_keyword}")
+    if "error" not in realtime_keyword:
+        logger.info(f"실시간 트렌드 LLM 응답: {realtime_keyword}")
 
     # 실시간 트렌드 키워드 저장
     if realtime_keyword and "trends" in realtime_keyword:

--- a/external/log/discord_handler.py
+++ b/external/log/discord_handler.py
@@ -1,6 +1,17 @@
 import logging
 import requests
 import traceback
+from datetime import datetime
+
+
+_FIELD_LIMIT = 1000   # Discord embed field value 최대 1024자에서 여유 두기
+_TRACEBACK_LIMIT = 3000  # Discord embed description 최대 4096자에서 여유 두기
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "\n...(생략됨)"
 
 
 class DiscordWebhookHandler(logging.Handler):
@@ -10,29 +21,46 @@ class DiscordWebhookHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord):
         try:
-            message = self.format(record)
+            tb_text = ""
+            if record.exc_info:
+                tb_text = "".join(traceback.format_exception(*record.exc_info))
+
+            # 엔드포인트 정보 (exception handler에서 extra로 전달)
+            endpoint = getattr(record, "endpoint", None)
+            fields = [
+                {"name": "Logger", "value": f"`{record.name}:{record.lineno}`", "inline": True},
+                {"name": "Level",  "value": f"`{record.levelname}`",            "inline": True},
+            ]
+            if endpoint:
+                fields.append({"name": "Endpoint", "value": f"`{endpoint}`", "inline": False})
+
+            fields.append({
+                "name": "Message",
+                "value": _truncate(record.getMessage(), _FIELD_LIMIT),
+                "inline": False,
+            })
+
+            if tb_text:
+                fields.append({
+                    "name": "Traceback",
+                    "value": f"```python\n{_truncate(tb_text, _TRACEBACK_LIMIT)}\n```",
+                    "inline": False,
+                })
 
             payload = {
-                "content": f"🚨 **FastAPI ERROR** 🚨\n```{message}```"
+                "embeds": [{
+                    "title": "🚨 FastAPI ERROR",
+                    "color": 0xE74C3C,
+                    "fields": fields,
+                    "timestamp": datetime.utcnow().isoformat(),
+                }]
             }
 
-            requests.post(
-                self.webhook_url,
-                json=payload,
-                timeout=3
-            )
+            requests.post(self.webhook_url, json=payload, timeout=3)
         except Exception:
-            # 로깅 실패로 서버 죽으면 안 됨, 하지만 문제 인지를 위해 stderr에 출력
             traceback.print_exc()
 
 
 class DiscordFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
-        base_message = super().format(record)
-
-        if record.exc_info:
-            base_message += "\n" + "".join(
-                traceback.format_exception(*record.exc_info)
-            )
-
-        return base_message
+        return super().format(record)

--- a/external/rag/chunk_service.py
+++ b/external/rag/chunk_service.py
@@ -196,7 +196,7 @@ async def create_meaning_chunks_with_focus(
             row_list.append([avg_audienceWatchRatio, avg_relativeRetentionPerformance])
             
         else:
-            pass
+            chunk_size = base_chunk_size_sec
 
         current_time += chunk_size
     context = json.dumps(chunk_list, ensure_ascii=False)

--- a/external/rag/rag_service_impl.py
+++ b/external/rag/rag_service_impl.py
@@ -297,6 +297,7 @@ class RagServiceImpl(RagService):
         logger.info(f"📈 Google Trends 실시간 트렌드 API 호출 완료 ({trends_time:.2f}초) - {len(raw_trends) if raw_trends else 0}개 트렌드")
         
         if not raw_trends:
+            logger.error("Google Trends 데이터 조회 실패 - 빈 결과 반환")
             return {"error": "트렌드 데이터를 가져올 수 없습니다."}
         
         current_date = datetime.now().strftime("%Y년 %m월 %d일")
@@ -328,9 +329,10 @@ class RagServiceImpl(RagService):
             result = json.loads(clean_json_str)
             return result
         except json.JSONDecodeError:
+            logger.error(f"실시간 트렌드 LLM 응답 JSON 파싱 실패 - 원본 응답: {result_str}")
             return {"error": "결과 파싱 오류", "raw_result": result_str}
-    
-    
+
+
 
     def analyze_channel_trends(
         self,
@@ -408,6 +410,7 @@ class RagServiceImpl(RagService):
             result = json.loads(clean_json_str)
             return result
         except json.JSONDecodeError:
+            logger.error(f"채널 맞춤형 트렌드 LLM 응답 JSON 파싱 실패 - 원본 응답: {result_str}")
             return {"error": "결과 파싱 오류", "raw_result": result_str}
 
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import logging
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
 from core.config.logging_config import setup_logging
 from core.config.database_config import test_pg_connection
@@ -60,6 +61,16 @@ async def on_shutdown():
     # kafka 브로커 종료
     await kafka_broker.close()
     logger.info("Kafka 브로커 종료 완료")
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    logger.error(
+        f"{type(exc).__name__}: {exc}",
+        exc_info=(type(exc), exc, exc.__traceback__),
+        extra={"endpoint": f"{request.method} {request.url.path}"},
+    )
+    return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
+
 
 @app.get("/health")
 async def health_check():


### PR DESCRIPTION
## PR 제목
[Feat/Fix/Refactor/Docs/Chore 등]: 간결하게 변경 내용을 요약해주세요. (예: Feat: 사용자 로그인 기능 구현)

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
구체적으로 어떤 변경 사항이 있는지, 왜 이러한 변경이 필요한지 설명해주세요.
(예: 사용자 회원가입 시 이메일 중복 확인 로직 추가. 기존 로직에서 누락된 부분 발견하여 수정.)

이탈 시점 분석 후, 이탈원인을 파악할 때, 자막을 청킹해서 자막 데이터를 저장하는 과정에서,
집중 청킹 일때와 기본 청킹 사이즈를 다르게 했었는데, 이 부분에서, 청킹 사이즈를 잘 못 바꿔서 생겼던 거 같습니다.
이 부분 수정하였습니다.

추가로, fastapi쪽 에러가 디코로 웹훅이 잘 안오거나, 그라파나 상에서 잘 찍히지 않는 경우가 있었는데,
2000줄이 넘는 경우에는 디코가 오지 않는다고 해서, 에러 헨들러 부분에 설정을 추가하였습니다.

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
해당 PR이 해결하는 이슈 또는 관련 있는 이슈가 있다면 링크를 걸어주세요.
(예: #123, ABC-456)

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.